### PR TITLE
Enlarge a bit the general font-size for gnome-shell

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -24,7 +24,7 @@ $corner_radius: 0px;
 //
 // Globals
 //
-$font-size: 9;
+$font-size: 10;
 $font-family: Futura Bk bt, Cantarell, Sans-Serif;
 $_bubble_bg_color: opacify($osd_bg_color,0.25);
 $_bubble_fg_color: $osd_fg_color;


### PR DESCRIPTION
This makes it looking way more nicer.

**Before:**
![Screenshot from 2019-03-19 21-45-58](https://user-images.githubusercontent.com/1237070/54640569-67479000-4a90-11e9-9075-0cd83fb6f328.png)

**After:**
![Screenshot from 2019-03-19 21-44-54](https://user-images.githubusercontent.com/1237070/54640508-44b57700-4a90-11e9-8193-4beed5c5aebd.png)
