### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Usage:  ./install.sh  [OPTIONS...]
 sudo ./install.sh -g -c dark -t standard  (Install standard dark gdm theme)
 ```
 
+### Flatpak
+
+All variants are available via Flathub:
+
+```
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub org.gtk.Gtk3theme.Qogir{,-dark,-light,-win,-manjaro, ...}
+```
+
 ## Screenshots
 ![1](https://github.com/vinceliuice/Qogir-theme/blob/images/screenshots/screenshot01.png?raw=true)
 ![2](https://github.com/vinceliuice/Qogir-theme/blob/images/screenshots/screenshot02.png?raw=true)


### PR DESCRIPTION
Added information about flatpak installation

All Qogir themes are now avalible via flathub.org.

```bash
 flatpak remote-ls | grep Qogir 
Qogir-dark	org.gtk.Gtk3theme.Qogir-dark		3.22	x86_64	flathub
Qogir-light	org.gtk.Gtk3theme.Qogir-light		3.22	x86_64	flathub
Qogir-manjaro-dark	org.gtk.Gtk3theme.Qogir-manjaro-dark		3.22	x86_64	flathub
Qogir-manjaro-light	org.gtk.Gtk3theme.Qogir-manjaro-light		3.22	x86_64	flathub
Qogir-manjaro-win-dark	org.gtk.Gtk3theme.Qogir-manjaro-win-dark		3.22	x86_64	flathub
...
```

