### PR TITLE
Respect interface font

### DIFF
--- a/src/gnome-shell/theme/gnome-shell.css
+++ b/src/gnome-shell/theme/gnome-shell.css
@@ -17,7 +17,6 @@
  * Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 stage {
-  font-family: Futura Bk bt, Cantarell, Sans-Serif;
   font-size: 10pt;
   color: #5c616c;
 }


### PR DESCRIPTION
Removed the opinionated font selection to follow GNOME 3.36's shell font changes.
I only edited one CSS file to see if you like the change. If you do, the other CSS files would need to be changed too, of course.