### PR TITLE
Change yum to dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Gnome ≥ 3.22:
 
 Fedora/RedHat distros:
 
-    yum install gtk-murrine-engine gtk2-engines
+    dnf install gtk-murrine-engine gtk2-engines
 
 Ubuntu/Mint/Debian distros:
 


### PR DESCRIPTION
Both RHEL/CentOS (as of version 8, if I recall correctly) and Fedora have moved on from yum to dnf, so I think it is reasonable to change this to reflect that.