### PR TITLE
Resized login inputs

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -2907,6 +2907,21 @@ $legacy_icon_size: 24px;
       &:active { @include button(active); }
       &:insensitive { @include button(insensitive); }
     }
+    &.button.cancel-button {
+      padding-left: 0;
+      padding-right: 0;
+      max-height: 2em;
+      height: 2em;
+      width: 2em;
+      StIcon {
+        icon-size: 1.5em;
+      }
+    }
+  }
+  StPasswordEntry {
+    padding-top: 0;
+    padding-bottom: 0;
+    max-height: 2em;
   }
 }
 
@@ -2963,7 +2978,6 @@ $legacy_icon_size: 24px;
   font-size: 120%;
   font-weight: bold;
   text-align: left;
-  padding-left: 15px;
 }
 
 .user-widget.horizontal .user-widget-label {


### PR DESCRIPTION
The password textbox and back button in the login and lock screens have weird dimensions. Also the user name not centered its moved a bit to the right.
This fixes them to more comfortable dimensions.

Before:
![20200621123055](https://user-images.githubusercontent.com/43451836/85232764-cba57d80-b3be-11ea-8e83-9ce4829a797c.png)
![20200621123124](https://user-images.githubusercontent.com/43451836/85232822-4cfd1000-b3bf-11ea-8c50-8c30e82abae3.png)


After:
![20200621123528](https://user-images.githubusercontent.com/43451836/85232767-d102c800-b3be-11ea-91e9-293e0c4ca8ce.png)
![20200621123557](https://user-images.githubusercontent.com/43451836/85232823-4ec6d380-b3bf-11ea-8144-9c346ae18df2.png)


