### PR TITLE
Fixed lock screen clock

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -3031,11 +3031,13 @@ $legacy_icon_size: 24px;
   padding-bottom: 1.5em;
 }
 
+.unlock-dialog-clock-time,
 .screen-shield-clock-time {
   font-size: 72pt;
   text-shadow: 0px 2px 2px rgba(0,0,0,0.4);
 }
 
+.unlock-dialog-clock-date,
 .screen-shield-clock-date { font-size: 28pt; }
 
 .screen-shield-notifications-container {


### PR DESCRIPTION
Gnome updated the class names for the clock and date elements in the lock screen.

Before:
![20200621123116](https://user-images.githubusercontent.com/43451836/85232890-0eb42080-b3c0-11ea-909c-5c9bc25f52e9.png)

After:
![20200621123545](https://user-images.githubusercontent.com/43451836/85232893-1378d480-b3c0-11ea-8b24-151c01eca4a7.png)
