### PR TITLE
Fixed polkit user icon

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -733,7 +733,7 @@ StScrollBar {
     color: $warning_color;
   }
 
-  &-user-icon {
+  &-icon {
     border-radius: 100px;
     background-size: contain;
     margin: 6px;


### PR DESCRIPTION
In polkit when asking for the user password `user-` was repeated in the selector.
The icon now is a circle and looks clearer.

Before:
![20200621123151](https://user-images.githubusercontent.com/43451836/85232973-9732c100-b3c0-11ea-89d1-cd6337a86df5.png)

After:
![20200621123617](https://user-images.githubusercontent.com/43451836/85232982-a4e84680-b3c0-11ea-98ee-398796c14542.png)
