### PR TITLE
Fix dash to dock transparency

### DIFF
--- a/src/_sass/gnome-shell/_extensions.scss
+++ b/src/_sass/gnome-shell/_extensions.scss
@@ -116,31 +116,24 @@ $empty_shadow: 0 0 0 transparent;
 
   #dash { // default-mode
     background-color: $dash_bg;
-    box-shadow: $empty_shadow;
   }
 
   &.opaque #dash { // solid-mode
     background-color: $dash_bg;
-    // FIXME: enforce opaque background
-    box-shadow: inset 0 0 0 9999px $dash_bg;
   }
 
   &.transparent #dash { // translucent-mode
     background-color: rgba($dash_bg, 0.75); // does not work
-    // FIXME: add lacked alpha via box-shadow property
-    box-shadow: inset 0 0 0 9999px rgba($dash_bg, 0.75);
   }
 
   &:overview #dash { // overview-mode #1
     background-color: $dash_bg;
-    box-shadow: $empty_shadow;
   }
 
   &.opaque:overview,
   &.transparent:overview { // overview-mode #2
     #dash {
       background-color: $dash_bg;
-      box-shadow: none !important;
     }
   }
 
@@ -149,7 +142,6 @@ $empty_shadow: 0 0 0 transparent;
   &.transparent.extended:overview {
     #dash {
       background-color: $dash_bg;
-      box-shadow: $empty_shadow;
     }
   }
 

--- a/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme-manjaro/gnome-shell-light.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-light.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme-manjaro/gnome-shell.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme-ubuntu/gnome-shell.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme/gnome-shell-dark.css
+++ b/src/gnome-shell/theme/gnome-shell-dark.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme/gnome-shell-light.css
+++ b/src/gnome-shell/theme/gnome-shell-light.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,

--- a/src/gnome-shell/theme/gnome-shell.css
+++ b/src/gnome-shell/theme/gnome-shell.css
@@ -3740,32 +3740,26 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dashtodockContainer #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque #dash {
   background-color: #32343D;
-  box-shadow: inset 0 0 0 9999px #32343D;
 }
 
 #dashtodockContainer.transparent #dash {
   background-color: rgba(50, 52, 61, 0.75);
-  box-shadow: inset 0 0 0 9999px rgba(50, 52, 61, 0.75);
 }
 
 #dashtodockContainer:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
   background-color: #32343D;
-  box-shadow: none !important;
 }
 
 #dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
   background-color: #32343D;
-  box-shadow: 0 0 0 transparent;
 }
 
 #dashtodockContainer .app-well-app .overview-icon,


### PR DESCRIPTION
When using dash to dock dynamic transparency with Qogir it didn't respect the alphas and used full opacity.

Before:
![before](https://user-images.githubusercontent.com/43451836/87232162-1ee56d00-c37a-11ea-9347-4b5e14785c7e.gif)

After:
![after](https://user-images.githubusercontent.com/43451836/87232166-2278f400-c37a-11ea-9a02-3415d9d29813.gif)
