### PR TITLE
Center dash to dock window preview

### DIFF
--- a/src/_sass/gnome-shell/_extensions.scss
+++ b/src/_sass/gnome-shell/_extensions.scss
@@ -229,6 +229,13 @@ $empty_shadow: 0 0 0 transparent;
   }
 }
 
+.popup-menu.app-well-menu {
+  .popup-menu-item.dashtodock-app-well-preview-menu-item {
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+}
+
 // /***************************
 //  * Dash To Panel Extension *
 //  ***************************/

--- a/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #2eb398;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme-manjaro/gnome-shell-light.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-light.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #2eb398;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme-manjaro/gnome-shell.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #2eb398;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #fb8441;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #fb8441;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #fb8441;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme/gnome-shell-dark.css
+++ b/src/gnome-shell/theme/gnome-shell-dark.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #5294e2;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme/gnome-shell-light.css
+++ b/src/gnome-shell/theme/gnome-shell-light.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #5294e2;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;

--- a/src/gnome-shell/theme/gnome-shell.css
+++ b/src/gnome-shell/theme/gnome-shell.css
@@ -3866,6 +3866,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border: 1px solid #5294e2;
 }
 
+.popup-menu.app-well-menu .popup-menu-item.dashtodock-app-well-preview-menu-item {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 #panel.dashtopanelMainPanel.dashtopanelTop {
   background-gradient-start: #21232b;
   background-gradient-end: #D3DAE3;


### PR DESCRIPTION
Dash to dock window preview was offset and it could even overflow.

Before:
![20200706185513](https://user-images.githubusercontent.com/43451836/87232271-cc588080-c37a-11ea-9e26-107556808514.png)
![20200706185526](https://user-images.githubusercontent.com/43451836/87232272-cd89ad80-c37a-11ea-8731-5111f5a84b9a.png)

Aflter:
![20200706185837](https://user-images.githubusercontent.com/43451836/87232254-adf28500-c37a-11ea-9b9a-5eedfe6e5654.png)
![20200706185845](https://user-images.githubusercontent.com/43451836/87232258-b2b73900-c37a-11ea-9b0e-dfd2f158e36e.png)
