### PR TITLE
Fix length warning

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -1421,7 +1421,6 @@ StScrollBar {
 
   > * {
     background-image: url("common-assets/misc/activities.svg");
-    background-position: center top;
     width: 24px;
     height: 24px;
     background-color: transparent !important;

--- a/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme-manjaro/gnome-shell-light.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-light.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme-manjaro/gnome-shell.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme-ubuntu/gnome-shell.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme/gnome-shell-dark.css
+++ b/src/gnome-shell/theme/gnome-shell-dark.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme/gnome-shell-light.css
+++ b/src/gnome-shell/theme/gnome-shell-light.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;

--- a/src/gnome-shell/theme/gnome-shell.css
+++ b/src/gnome-shell/theme/gnome-shell.css
@@ -1474,7 +1474,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #panel #panelActivities.panel-button > * {
   background-image: url("common-assets/misc/activities.svg");
-  background-position: center top;
   width: 24px;
   height: 24px;
   background-color: transparent !important;


### PR DESCRIPTION
Gnome-shell shows this warning `Ignoring length property that isn't a number at line 1477, col 24`.
It doesn't support keywords for `background-position` and ignores these values.
