### PR TITLE
Fix gnome-shell spinner

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -998,7 +998,7 @@ StScrollBar {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 

--- a/src/gnome-shell/gnome-shell-theme.gresource.xml
+++ b/src/gnome-shell/gnome-shell-theme.gresource.xml
@@ -45,7 +45,7 @@
     <file>common-assets/misc/page-indicator-checked.svg</file>
     <file>common-assets/misc/page-indicator-hover.svg</file>
     <file>common-assets/misc/page-indicator-inactive.svg</file>
-    <file>common-assets/misc/process-working.svg</file>
+    <file alias="process-working.svg">common-assets/misc/process-working.svg</file>
     <file>common-assets/misc/ws-switch-arrow-down.png</file>
     <file>common-assets/misc/ws-switch-arrow-up.png</file>
     <file>common-assets/switch/switch-off-selected.svg</file>

--- a/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-dark.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme-manjaro/gnome-shell-light.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell-light.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme-manjaro/gnome-shell.css
+++ b/src/gnome-shell/theme-manjaro/gnome-shell.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-dark.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell-light.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme-ubuntu/gnome-shell.css
+++ b/src/gnome-shell/theme-ubuntu/gnome-shell.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme/gnome-shell-dark.css
+++ b/src/gnome-shell/theme/gnome-shell-dark.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme/gnome-shell-light.css
+++ b/src/gnome-shell/theme/gnome-shell-light.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }

--- a/src/gnome-shell/theme/gnome-shell.css
+++ b/src/gnome-shell/theme/gnome-shell.css
@@ -1063,7 +1063,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #appMenu {
-  spinner-image: url("common-assets/misc/process-working.svg");
+  spinner-image: url("process-working.svg");
   spacing: 4px;
   padding: 0 8px;
 }


### PR DESCRIPTION
Gnome-shell shows this warning `Failed to open sliced image: The resource at “/org/gnome/shell/theme/process-working.svg” does not exist`. It has hard coded that path for that icon.
It is used by things like the login screen and in the panel when opening an application, so it cannot be changed in the css.