### PR TITLE
Align nautilus window buttons

### DIFF
--- a/src/_sass/gtk/_darksidebar_widgets.scss
+++ b/src/_sass/gtk/_darksidebar_widgets.scss
@@ -243,7 +243,7 @@ filechooser {
   }
 
   headerbar {
-    padding-left: 48px;
+    padding-left: 44px;
     @extend %headerbar_image; // Set nautilus headerbar mountain icon
 
     &, &:backdrop {

--- a/src/gtk/theme-3.0/gtk-Dark.css
+++ b/src/gtk/theme-3.0/gtk-Dark.css
@@ -10455,7 +10455,7 @@ filechooser paned > separator {
 }
 
 .nautilus-window headerbar {
-  padding-left: 48px;
+  padding-left: 44px;
 }
 
 .nautilus-window headerbar, .nautilus-window headerbar:backdrop {

--- a/src/gtk/theme-3.0/gtk-Light.css
+++ b/src/gtk/theme-3.0/gtk-Light.css
@@ -10427,7 +10427,7 @@ filechooser paned > separator {
 }
 
 .nautilus-window headerbar {
-  padding-left: 48px;
+  padding-left: 44px;
 }
 
 .nautilus-window headerbar, .nautilus-window headerbar:backdrop {

--- a/src/gtk/theme-3.0/gtk.css
+++ b/src/gtk/theme-3.0/gtk.css
@@ -10443,7 +10443,7 @@ filechooser paned > separator {
 }
 
 .nautilus-window headerbar {
-  padding-left: 48px;
+  padding-left: 44px;
 }
 
 .nautilus-window headerbar, .nautilus-window headerbar:backdrop {


### PR DESCRIPTION
The close button in nautilus is not correctly aligned when using the window buttons on the left.

Before
![before-left](https://user-images.githubusercontent.com/43451836/196068735-f0ae29ce-93a4-4988-a201-49b7319604af.png)
![before-right](https://user-images.githubusercontent.com/43451836/196068737-2aa5c2a3-bc56-4d15-ad1e-ae930bdbe8bd.png)

After
![after-left](https://user-images.githubusercontent.com/43451836/196068742-afc6dccd-4588-48c1-abb2-31f36e4d781f.png)
![after-right](https://user-images.githubusercontent.com/43451836/196068743-88150c6d-988e-41d8-9d2f-f98769ffacee.png)
