### PR TITLE
Add screenshot UI support

### DIFF
--- a/src/_sass/_colors.scss
+++ b/src/_sass/_colors.scss
@@ -11,7 +11,7 @@ $fg_color: if($variant =='light', #464853, #e6ebef);
 $alt_base_color: if($variant == 'light', darken($base_color, 5%), lighten($base_color, 5%));
 $sec_base_color: if($variant == 'light', darken($base_color, 10%), lighten($base_color, 10%));
 $alt_bg_color: if($variant == 'light', darken($bg_color, 5%), lighten($bg_color, 5%));
-$sec_bg_color: dif($variant == 'light', darken($bg_color, 10%), lighten($bg_color, 10%));
+$sec_bg_color: if($variant == 'light', darken($bg_color, 10%), lighten($bg_color, 10%));
 $alt_fg_color: rgba($fg_color, 0.75);
 $sec_fg_color: rgba($fg_color, 0.6);
 

--- a/src/_sass/gnome-shell/_widgets-42-0.scss
+++ b/src/_sass/gnome-shell/_widgets-42-0.scss
@@ -27,6 +27,7 @@
 @import 'widgets-common/osd';
 @import 'widgets-common/switcher-popup';
 @import 'widgets-common/workspace-switcher';
+@import 'widgets-common/screenshot';
 // Panel
 @import 'widgets-common/panel';
 @import 'widgets-common/corner-ripple';

--- a/src/_sass/gnome-shell/widgets-common/_screenshot.scss
+++ b/src/_sass/gnome-shell/widgets-common/_screenshot.scss
@@ -1,0 +1,204 @@
+// Screenshot UI
+.icon-label-button-container {
+  spacing: $cont_padding;
+  font-weight: 400;
+  @include fontsize(9);
+
+  StIcon { icon-size: 32px;}
+}
+
+$screenshot_ui_panel_padding: $cont_padding * 3;
+$screenshot_ui_shot_cast_margin: 21px;
+$screenshot_ui_panel_border_radius: $corner_radius;
+$screenshot_ui_shot_cast_spacing: 3px;
+$screenshot_ui_base_icon_size: 1.09em;
+$screenshot_ui_button_red: $error_color;
+
+.screenshot-ui-panel {
+  @extend %osd_panel;
+  border-radius: $screenshot_ui_panel_border_radius;
+  padding: $screenshot_ui_panel_padding;
+  // Reduce the bottom padding a little to accommodate the large capture button.
+  padding-bottom: $screenshot_ui_panel_padding - 6px;
+  margin-bottom: 4em;
+  spacing: $cont_padding * 2;
+}
+
+.screenshot-ui-close-button {
+  @extend .window-close; // copy window close button
+  padding: $cont_padding !important; // but with more padding
+  margin-top: 12px;
+  &.left { margin-left: 12px;}
+  &.right { margin-right: 12px;}
+}
+
+.screenshot-ui-type-button {
+  @extend %osd_button;
+  min-width: 48px;
+  padding: $cont_padding * 2 $cont_padding * 3 !important;
+  border-radius: $bt_radius;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 99px;
+  border: 4px $osd_fg_color;
+  padding: 4px;
+
+  .screenshot-ui-capture-button-circle {
+    background-color: $osd_fg_color;
+    transition-duration: 200ms;
+    &:hover, &:focus { background-color: $alt_bg_color;}
+    border-radius: 99px;
+  }
+
+  &:hover, &:focus {
+    .screenshot-ui-capture-button-circle {
+      background-color: darken($osd_fg_color, 15%);
+    }
+  }
+
+  &:active {
+    .screenshot-ui-capture-button-circle {
+      background-color: darken($osd_fg_color, 50%);
+    }
+  }
+
+  &:cast {
+    .screenshot-ui-capture-button-circle {
+      background-color: $screenshot_ui_button_red;
+    }
+    &:hover, &:focus {
+      .screenshot-ui-capture-button-circle {
+        background-color: lighten($screenshot_ui_button_red, 5%);
+      }
+    }
+    &:active {
+      .screenshot-ui-capture-button-circle {
+        background-color: darken($screenshot_ui_button_red, 7%);
+      }
+    }
+  }
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: lighten($osd_bg_color,5%);
+  border-radius: $bt_radius;
+  padding: $screenshot_ui_shot_cast_spacing;
+  spacing: $screenshot_ui_shot_cast_spacing;
+
+  &:ltr { margin-left: $screenshot_ui_shot_cast_margin - $screenshot_ui_panel_padding;}
+  &:rtl { margin-right: $screenshot_ui_shot_cast_margin - $screenshot_ui_panel_padding;}
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: $cont_padding $cont_padding*2;
+  background-color: transparent;
+  &:hover, &:focus { background-color: lighten($osd_bg_color, 10%);}
+  &:active { background-color: lighten($sec_bg_color,5%);}
+  &:checked { background-color: white;color: black;}
+  &:insensitive { color: transparentize($osd_fg_color, 0.5);}
+
+  border-radius: $bt_radius;
+
+  StIcon { icon-size: $screenshot_ui_base_icon_size;}
+}
+
+.screenshot-ui-show-pointer-button {
+  @extend %osd_button;
+  border-radius: 99px;
+  padding: $cont_padding * 2 !important;
+  StIcon { icon-size: $screenshot_ui_base_icon_size;}
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0,0,0,.3);
+}
+
+.screenshot-ui-area-selector {
+  .screenshot-ui-area-indicator-shade {
+    background-color: rgba(0,0,0,.5);
+  }
+
+  .screenshot-ui-area-indicator-selection {
+    border: 2px white;
+  }
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 99px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0,0,0,0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: $base_color;
+
+  .screenshot-ui-window-selector-window-container {
+    margin: 100px;
+  }
+
+  &:primary-monitor {
+    .screenshot-ui-window-selector-window-container {
+      // Make some room for the panel.
+      margin-bottom: 200px;
+    }
+  }
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: $corner_radius;
+  border: 2px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 99px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window {
+  &:hover {
+    .screenshot-ui-window-selector-window-border {
+      border-color: darken($selected_bg_color, 15%);
+    }
+  }
+  &:checked {
+    .screenshot-ui-window-selector-window-border {
+      border-color: $selected_bg_color;
+      background-color: transparentize($selected_bg_color, 0.8);
+    }
+
+    .screenshot-ui-window-selector-check {
+      color: $selected_fg_color;
+      background-color: $selected_bg_color;
+    }
+  }
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0,0,0,.5);
+
+  &:hover { background-color: rgba(0,0,0,.3);}
+  &:active { background-color: rgba(0,0,0,.7);}
+  &:checked {
+    background-color: transparent;
+    border: 2px white;
+  }
+}
+
+.screenshot-ui-tooltip {
+  color: $_shell_fg_color;
+  background-color: rgba(darken($osd_bg_color, 8%), 0.95);
+  border-radius: $bt_radius;
+  padding: 4px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}

--- a/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
@@ -645,7 +645,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 
@@ -663,7 +663,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 

--- a/src/gnome-shell/theme-3-32/gnome-shell.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell.css
@@ -645,7 +645,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 
@@ -663,7 +663,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 

--- a/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
@@ -645,7 +645,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 
@@ -663,7 +663,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 

--- a/src/gnome-shell/theme-40-0/gnome-shell.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell.css
@@ -645,7 +645,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 
@@ -663,7 +663,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 

--- a/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
@@ -80,7 +80,7 @@
   box-shadow: 0 3px 8px -3px rgba(0, 0, 0, 0.35) !important;
 }
 
-.workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
   color: #D3DAE3;
   background-color: #282A33;
   border-radius: 3px;
@@ -233,6 +233,46 @@ StEntry StLabel.hint-text {
   color: rgba(230, 235, 239, 0.45);
   border: 1px solid rgba(255, 255, 255, 0);
   background-color: rgba(44, 47, 57, 0.55);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  text-shadow: none;
+  color: #D3DAE3;
+  border: 1px solid #333641;
+  background-color: #282A33;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  text-shadow: none;
+  color: #D3DAE3;
+  border-color: #3e4250;
+  background-color: #333641;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  text-shadow: none;
+  color: #D3DAE3;
+  border-color: #216dc6;
+  background-color: #282A33;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  text-shadow: none;
+  color: #ffffff;
+  border-color: #5294e2;
+  background-color: #5294e2;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  text-shadow: none;
+  color: rgba(211, 218, 227, 0.35);
+  border-color: rgba(0, 0, 0, 0.15);
+  background-color: rgba(62, 66, 80, 0.35);
   box-shadow: none;
 }
 
@@ -645,7 +685,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 
@@ -663,7 +703,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #e6ebef;
-  background-color: dif(false, #1b1c21, #494c59);
+  background-color: #494c59;
   border: none;
 }
 
@@ -1900,6 +1940,219 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #ffffff;
 }
 
+.icon-label-button-container {
+  spacing: 6px;
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 0;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px !important;
+  margin-top: 12px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 12px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 12px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 12px 18px !important;
+  border-radius: 2px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 99px;
+  border: 4px #D3DAE3;
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: #D3DAE3;
+  transition-duration: 200ms;
+  border-radius: 99px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: #3d404b;
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #a4b3c5;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: #475970;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #FC4138;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #fc5951;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #fb1f15;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: #333641;
+  border-radius: 2px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 2px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: #3e4250;
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: #545867;
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button:insensitive {
+  color: rgba(211, 218, 227, 0.5);
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 1.09em;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 99px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 1.09em;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 99px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #282A33;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 0;
+  border: 2px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 99px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #216dc6;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #5294e2;
+  background-color: rgba(82, 148, 226, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: #ffffff;
+  background-color: #5294e2;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: rgba(22, 23, 28, 0.95);
+  border-radius: 2px;
+  padding: 4px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
 /* Top Bar */
 #panel {
   font-weight: normal;
@@ -2104,7 +2357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-size: 10pt;
 }
 
-.window-close {
+.window-close, .screenshot-ui-close-button {
   background-color: #5294e2;
   color: #ffffff;
   border: none;
@@ -2117,11 +2370,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -shell-close-overlap: 16px;
 }
 
-.window-close:hover {
+.window-close:hover, .screenshot-ui-close-button:hover {
   background-color: #68a2e6;
 }
 
-.window-close:active {
+.window-close:active, .screenshot-ui-close-button:active {
   background-color: #3c86de;
 }
 

--- a/src/gnome-shell/theme-42-0/gnome-shell.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell.css
@@ -80,7 +80,7 @@
   box-shadow: 0 3px 8px -3px rgba(0, 0, 0, 0.35) !important;
 }
 
-.workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
   color: #D3DAE3;
   background-color: #282A33;
   border-radius: 3px;
@@ -233,6 +233,46 @@ StEntry StLabel.hint-text {
   color: rgba(70, 72, 83, 0.55);
   border: 1px solid rgba(0, 0, 0, 0);
   background-color: rgba(255, 255, 255, 0.55);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  text-shadow: none;
+  color: #D3DAE3;
+  border: 1px solid #333641;
+  background-color: #282A33;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  text-shadow: none;
+  color: #D3DAE3;
+  border-color: #3e4250;
+  background-color: #333641;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  text-shadow: none;
+  color: #D3DAE3;
+  border-color: #216dc6;
+  background-color: #282A33;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  text-shadow: none;
+  color: #ffffff;
+  border-color: #5294e2;
+  background-color: #5294e2;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  text-shadow: none;
+  color: rgba(211, 218, 227, 0.35);
+  border-color: rgba(0, 0, 0, 0.15);
+  background-color: rgba(62, 66, 80, 0.35);
   box-shadow: none;
 }
 
@@ -645,7 +685,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day-base:active, .calendar-day-base:checked, .calendar-day-base:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 
@@ -663,7 +703,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar-day:active, .calendar-day:checked, .calendar-day:selected {
   color: #464853;
-  background-color: dif(true, #dae2e9, white);
+  background-color: #dae2e9;
   border: none;
 }
 
@@ -1900,6 +1940,219 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #ffffff;
 }
 
+.icon-label-button-container {
+  spacing: 6px;
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 0;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px !important;
+  margin-top: 12px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 12px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 12px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 12px 18px !important;
+  border-radius: 2px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 99px;
+  border: 4px #D3DAE3;
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: #D3DAE3;
+  transition-duration: 200ms;
+  border-radius: 99px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: #eaeef2;
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #a4b3c5;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: #475970;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #FC4138;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #fc5951;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #fb1f15;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: #333641;
+  border-radius: 2px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 2px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: #3e4250;
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: #eaeef2;
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button:insensitive {
+  color: rgba(211, 218, 227, 0.5);
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 1.09em;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 99px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 1.09em;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 99px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #ffffff;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 0;
+  border: 2px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 99px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #216dc6;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #5294e2;
+  background-color: rgba(82, 148, 226, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: #ffffff;
+  background-color: #5294e2;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: rgba(22, 23, 28, 0.95);
+  border-radius: 2px;
+  padding: 4px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
 /* Top Bar */
 #panel {
   font-weight: normal;
@@ -2104,7 +2357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-size: 10pt;
 }
 
-.window-close {
+.window-close, .screenshot-ui-close-button {
   background-color: #5294e2;
   color: #ffffff;
   border: none;
@@ -2117,11 +2370,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -shell-close-overlap: 16px;
 }
 
-.window-close:hover {
+.window-close:hover, .screenshot-ui-close-button:hover {
   background-color: #68a2e6;
 }
 
-.window-close:active {
+.window-close:active, .screenshot-ui-close-button:active {
   background-color: #3c86de;
 }
 


### PR DESCRIPTION
The screenshot UI was missing and it was basically transparent. It also matches the rounded corners if the tweak is installed.

Fixes #235 

![screen](https://user-images.githubusercontent.com/43451836/197429869-ea7a1206-c88b-490a-95a6-3fb064fd9dfe.png)
![video selection](https://user-images.githubusercontent.com/43451836/197429875-ddfaca08-2b03-4876-920e-60a34609c41d.png)
![window](https://user-images.githubusercontent.com/43451836/197429879-6f2036a2-cba7-42c0-a60e-376778a18e61.png)
![window rounded corners](https://user-images.githubusercontent.com/43451836/197429880-c6735cb4-b8b5-46b6-89fe-5d5f92423211.png)
