### PR TITLE
Fix popup menu selected colors

### DIFF
--- a/src/_sass/gnome-shell/widgets-common/_slider.scss
+++ b/src/_sass/gnome-shell/widgets-common/_slider.scss
@@ -23,6 +23,8 @@
   -barlevel-overdrive-border-color: $destructive_color;
   -barlevel-overdrive-separator-width: 2px;
 
+  .popup-menu-item:hover &,
+  .popup-menu-item:focus &,
   .popup-menu-item.selected & {
     -slider-background-color: rgba(black, 0.2);
     -slider-active-background-color: $selected_fg_color;

--- a/src/_sass/gnome-shell/widgets-common/_switches.scss
+++ b/src/_sass/gnome-shell/widgets-common/_switches.scss
@@ -8,6 +8,8 @@
 
   &:checked { background-image: url("assets/switch-on.svg"); }
 
+  .popup-menu-item:hover &,
+  .popup-menu-item:focus &,
   .popup-menu-item.selected & {
     background-image: url("assets/switch-off-selected.svg");
 

--- a/src/gnome-shell/gnome-shell-theme.gresource.xml
+++ b/src/gnome-shell/gnome-shell-theme.gresource.xml
@@ -35,5 +35,13 @@
     <file alias="gdm3.css">gnome-shell.css</file>
     <file alias="Yaru/gnome-shell.css">gnome-shell.css</file>
     <file alias="Yaru-dark/gnome-shell.css">gnome-shell.css</file>
+    <file alias="Yaru/assets/switch-off.svg">assets/switch-off.svg</file>
+    <file alias="Yaru/assets/switch-on.svg">assets/switch-on.svg</file>
+    <file alias="Yaru/assets/switch-off-selected.svg">assets/switch-off-selected.svg</file>
+    <file alias="Yaru/assets/switch-on-selected.svg">assets/switch-on-selected.svg</file>
+    <file alias="Yaru-dark/assets/switch-off.svg">assets/switch-off.svg</file>
+    <file alias="Yaru-dark/assets/switch-on.svg">assets/switch-on.svg</file>
+    <file alias="Yaru-dark/assets/switch-off-selected.svg">assets/switch-off-selected.svg</file>
+    <file alias="Yaru-dark/assets/switch-on-selected.svg">assets/switch-on-selected.svg</file>
   </gresource>
 </gresources>

--- a/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
@@ -289,11 +289,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -319,7 +319,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);

--- a/src/gnome-shell/theme-3-32/gnome-shell.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell.css
@@ -289,11 +289,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -319,7 +319,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);

--- a/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
@@ -289,11 +289,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -319,7 +319,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);

--- a/src/gnome-shell/theme-40-0/gnome-shell.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell.css
@@ -289,11 +289,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -319,7 +319,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);

--- a/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
@@ -329,11 +329,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -359,7 +359,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);

--- a/src/gnome-shell/theme-42-0/gnome-shell.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell.css
@@ -329,11 +329,11 @@ StEntry StLabel.hint-text {
   background-image: url("assets/switch-on.svg");
 }
 
-.popup-menu-item.selected .toggle-switch {
+.popup-menu-item:hover .toggle-switch, .popup-menu-item:focus .toggle-switch, .popup-menu-item.selected .toggle-switch {
   background-image: url("assets/switch-off-selected.svg");
 }
 
-.popup-menu-item.selected .toggle-switch:checked {
+.popup-menu-item:hover .toggle-switch:checked, .popup-menu-item:focus .toggle-switch:checked, .popup-menu-item.selected .toggle-switch:checked {
   background-image: url("assets/switch-on-selected.svg");
 }
 
@@ -359,7 +359,7 @@ StEntry StLabel.hint-text {
   -barlevel-overdrive-separator-width: 2px;
 }
 
-.popup-menu-item.selected .slider {
+.popup-menu-item:hover .slider, .popup-menu-item:focus .slider, .popup-menu-item.selected .slider {
   -slider-background-color: rgba(0, 0, 0, 0.2);
   -slider-active-background-color: #ffffff;
   -barlevel-background-color: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
When moving the mouse outside of the selected item the highlight was not visible.

Before:
![before1](https://user-images.githubusercontent.com/43451836/198928223-bbad09cd-eef8-4243-a675-0bb2654517ed.png)
![before2](https://user-images.githubusercontent.com/43451836/198928226-d2df85ce-5435-4aea-92f1-e317bf7ffb55.png)

After:
![after1](https://user-images.githubusercontent.com/43451836/198928242-bc04fd80-fde1-4d45-94de-5da3b751e0ed.png)
![after2](https://user-images.githubusercontent.com/43451836/198928245-c1d31200-ef97-472d-ba9a-57c67e2c5f05.png)
