### PR TITLE
Fix icon theme case in theme definition

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,7 @@ install() {
   echo "[X-GNOME-Metatheme]"                                                      >> ${THEME_DIR}/index.theme
   echo "GtkTheme=${name}${theme}${color}"                                         >> ${THEME_DIR}/index.theme
   echo "MetacityTheme=${name}${theme}${color}"                                    >> ${THEME_DIR}/index.theme
-  echo "IconTheme=${name}${theme}${ELSE_DARK}"                                    >> ${THEME_DIR}/index.theme
+  echo "IconTheme=${name}${theme,,}${ELSE_DARK,,}"                                >> ${THEME_DIR}/index.theme
   echo "CursorTheme=Adwaita"                                                      >> ${THEME_DIR}/index.theme
   echo "ButtonLayout=menu:minimize,maximize,close"                                >> ${THEME_DIR}/index.theme
 


### PR DESCRIPTION
The `IconTheme` value is set to the same value as the theme. This is incorrect, as the icon themes are named using lowercase. For example: the icon theme for `Qogir-Ubuntu-Dark` is named `Qogir-ubuntu-dark`.

Fix this by setting the `IconTheme` to the correct lowercase equivalent.