### PR TITLE
clean-old-theme.sh is executed properly when running install.sh from another directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -719,7 +719,7 @@ uninstall_theme() {
   done
 }
 
-./clean-old-theme.sh
+${SRC_DIR}/clean-old-theme.sh
 
 if [[ "${gdm:-}" != 'true' && "${remove:-}" != 'true' ]]; then
   install_theme


### PR DESCRIPTION
Previously [`install.sh`](https://github.com/vinceliuice/Qogir-theme/blob/master/install.sh) would fail to run [`clean-old-theme.sh`](https://github.com/vinceliuice/Qogir-theme/blob/master/clean-old-theme.sh) unless launched from the source directory:

```bash
~ $ cd ~
~ $ /tmp/Qogir-theme-master/install.sh
'gnome-shell' not found, using styles for last gnome-shell version available.
/tmp/Qogir-theme-master/install.sh: line 722: ./clean-old-theme.sh: No such file or directory
Installing '/home/sidroberts/.themes/Qogir'...
Installing '/home/sidroberts/.themes/Qogir-Light'...
Installing '/home/sidroberts/.themes/Qogir-Dark'...

Done.
```