### PR TITLE
common.scss: fix menu applet text dpi bug

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -1399,11 +1399,9 @@ StScrollBar {
     padding-right: 30px;
     padding-left: 28px;
     text-align: right;
-    height: 30px;
 
     &:rtl {
       padding-top: 10px;
-      height: 30px;
     }
   }
 
@@ -1417,7 +1415,6 @@ StScrollBar {
 
 #menu-search-entry {
   width: 250px;
-  height: 15px;
   font-weight: normal;
   caret-color: $fg_color;
   margin-right: 6px;


### PR DESCRIPTION
When cinnamon text scaling or text sizes are bigger than the default, text does not fit in menu applet search entry or menu-selected-app-box so remove height limit to allow automatic widget sizing.

Fixes: https://github.com/linuxmint/cinnamon/issues/12126