### PR TITLE
Fix toggle icon size

### DIFF
--- a/src/_sass/gnome-shell/widgets-42-0/_quick-settings.scss
+++ b/src/_sass/gnome-shell/widgets-42-0/_quick-settings.scss
@@ -31,6 +31,7 @@
   &:rtl > StBoxLayout { padding-right: $cont_padding * 2.5; }
 
   .quick-toggle-label { font-weight: bold; }
+  .quick-toggle-icon { icon-size: 16px; }
 }
 
 .quick-menu-toggle {

--- a/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
@@ -3540,6 +3540,10 @@ StWidget.focused .app-well-app-running-dot {
   font-weight: bold;
 }
 
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
 .quick-menu-toggle:ltr > StBoxLayout {
   padding-right: 0;
 }

--- a/src/gnome-shell/theme-42-0/gnome-shell.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell.css
@@ -3540,6 +3540,10 @@ StWidget.focused .app-well-app-running-dot {
   font-weight: bold;
 }
 
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
 .quick-menu-toggle:ltr > StBoxLayout {
   padding-right: 0;
 }


### PR DESCRIPTION
In GNOME 43 the icon sizes of the toggles in the quick settings was too big. This only happened when installing as gdm theme.

Before:
![before](https://github.com/vinceliuice/Qogir-theme/assets/43451836/e1da62a9-dda0-46a6-abb1-7314bf1f2eea)

After:
![after](https://github.com/vinceliuice/Qogir-theme/assets/43451836/47d626ca-41a7-4448-8286-bddf788b1708)
