### PR TITLE
Fix popup separator menu item

### DIFF
--- a/src/_sass/gnome-shell/widgets-common/_popovers.scss
+++ b/src/_sass/gnome-shell/widgets-common/_popovers.scss
@@ -105,7 +105,6 @@
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 
   .popup-separator-menu-item-separator {
     //-margin-horizontal: 24px;

--- a/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell-Dark.css
@@ -540,7 +540,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-3-32/gnome-shell.css
+++ b/src/gnome-shell/theme-3-32/gnome-shell.css
@@ -540,7 +540,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell-Dark.css
@@ -540,7 +540,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-40-0/gnome-shell.css
+++ b/src/gnome-shell/theme-40-0/gnome-shell.css
@@ -540,7 +540,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
@@ -580,7 +580,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-42-0/gnome-shell.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell.css
@@ -580,7 +580,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-44-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-44-0/gnome-shell-Dark.css
@@ -605,7 +605,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-44-0/gnome-shell.css
+++ b/src/gnome-shell/theme-44-0/gnome-shell.css
@@ -605,7 +605,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-46-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-46-0/gnome-shell-Dark.css
@@ -604,7 +604,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {

--- a/src/gnome-shell/theme-46-0/gnome-shell.css
+++ b/src/gnome-shell/theme-46-0/gnome-shell.css
@@ -604,7 +604,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .popup-separator-menu-item {
   margin: 0 !important;
   padding: 0 !important;
-  height: 1px !important;
 }
 
 .popup-separator-menu-item .popup-separator-menu-item-separator {


### PR DESCRIPTION
The separator item was being hidden. For example in the case of gsconnect it contains useful information.
This only happens when installed as gdm theme.

Before:
![before](https://github.com/user-attachments/assets/fc732e19-50f5-454d-91a6-906f14e6eba6)


After:
![after](https://github.com/user-attachments/assets/2eeb099d-fe68-4322-9286-3585e777bbc7)
