### PR TITLE
Fix quick settings arrow size

### DIFF
--- a/src/_sass/gnome-shell/widgets-42-0/_quick-settings.scss
+++ b/src/_sass/gnome-shell/widgets-42-0/_quick-settings.scss
@@ -41,6 +41,7 @@
   .quick-toggle-arrow {
     background-color: rgba($fg_color, 0.06) !important;
     padding: $cont_padding $cont_padding * 1;
+    icon-size: 16px;
 
     &:active, &:checked {
       background-color: rgba($fg_color, 0.12) !important;

--- a/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell-Dark.css
@@ -3556,6 +3556,7 @@ StWidget.focused .app-well-app-running-dot {
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(230, 235, 239, 0.06) !important;
   padding: 6px 6px;
+  icon-size: 16px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active, .quick-menu-toggle .quick-toggle-arrow:checked {

--- a/src/gnome-shell/theme-42-0/gnome-shell.css
+++ b/src/gnome-shell/theme-42-0/gnome-shell.css
@@ -3556,6 +3556,7 @@ StWidget.focused .app-well-app-running-dot {
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(70, 72, 83, 0.06) !important;
   padding: 6px 6px;
+  icon-size: 16px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active, .quick-menu-toggle .quick-toggle-arrow:checked {


### PR DESCRIPTION
The arrows in the quick settings were disproportionally big.
This only happens when installed as gdm theme.

Before:
![before](https://github.com/user-attachments/assets/f3c158d5-7fa6-4525-b144-70b18a0d1447)

After:
![after](https://github.com/user-attachments/assets/dfa9f304-c535-4aa5-b0ed-5e890a378bc1)
