### PR TITLE
Script fix and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Fedora/RedHat distros:
 
     dnf install gtk-murrine-engine gtk2-engines
 
+openSUSE/SUSE distros:
+
+    zypper in gtk2-engine-murrine gtk2-engines
+
 Ubuntu/Mint/Debian distros:
 
     sudo apt-get install gtk2-engines-murrine gtk2-engines-pixbuf

--- a/install.sh
+++ b/install.sh
@@ -710,8 +710,8 @@ theme_tweaks() {
 }
 
 link_theme() {
-  for theme in "${THEME_VARIANTS[0]}"; do
-    for lcolor in "${COLOR_VARIANTS[1]}"; do
+  for theme in "${themes[@]}"; do
+    for lcolor in "${colors[@]}"; do
       link_libadwaita "${dest:-$DEST_DIR}" "${name:-$THEME_NAME}" "$theme" "$lcolor"
     done
   done


### PR DESCRIPTION

## Issue Description

When installing the theme with the parameter to install it as a dark theme (`-c dark`), the Adwaita linking fails, since it does not capture the right theme name. 

The README.md did not contain instructions on installing the dependencies for openSUSE.

## Steps to Reproduce

In the terminal, run:

`./install.sh -c dark -i opensuse -l`

This works, but doesn't do any linking, since the theme is always selected as `Qogir-Light`.

## Fix

The issue with installation happens because in `link_theme()` function, it had `COLOR_VARIANTS[1]` so it always took  '-Light'. This was changed to `colors[@]`. Subsequently I also changed `THEME_VARIANTS[0]` to `themes[@]` so that it also considers the right theme variant.

Added dependency installation instructions for openSUSE.
