### PR TITLE
Update gtk-Dark.css

### DIFF
--- a/src/gtk/theme-3.0/gtk-Dark.css
+++ b/src/gtk/theme-3.0/gtk-Dark.css
@@ -3938,7 +3938,7 @@ row:selected progressbar trough, infobar progressbar trough {
 }
 
 levelbar block {
-  min-width: 32px;
+  min-width: 0px;
   min-height: 1px;
 }
 


### PR DESCRIPTION
The Budgie Desktop "Usage Monitor" widget bar is not displayed correctly, after this change it can be displayed correctly.