### PR TITLE
Update _common-3.0.scss

### DIFF
--- a/src/_sass/gtk/_common-3.0.scss
+++ b/src/_sass/gtk/_common-3.0.scss
@@ -2914,7 +2914,7 @@ progressbar {
 //
 levelbar {
   block {
-    min-width: 32px;
+    min-width: 0px;
     min-height: 1px;
   }
 


### PR DESCRIPTION
The Budgie Desktop "Usage Monitor" widget bar is not displayed correctly, after this change it can be displayed correctly.