### PR TITLE
Small fixes in gtk4 round theme

### DIFF
--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -4717,7 +4717,6 @@ window {
               0 8px 8px 0 if($variant == 'light', rgba(black, 0.15), rgba(black, 0.12)),
               0 0 0 1px $borders_color;
   margin: 0;
-  border-radius: $corner_radius;
   transition: $backdrop_transition;
 
   &:backdrop {

--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -4717,7 +4717,6 @@ window {
               0 8px 8px 0 if($variant == 'light', rgba(black, 0.15), rgba(black, 0.12)),
               0 0 0 1px $borders_color;
   margin: 0;
-  transition: $backdrop_transition;
 
   &:backdrop {
     // the transparent shadow here is to enforce that the shadow extents don't

--- a/src/gtk/theme-4.0/gtk-Dark.css
+++ b/src/gtk/theme-4.0/gtk-Dark.css
@@ -5699,8 +5699,6 @@ window {
   outline: none;
   box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.12), 0 8px 8px 0 rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(255, 255, 255, 0.12);
   margin: 0;
-  border-radius: 0;
-  transition: 200ms ease-out;
 }
 
 window:backdrop {

--- a/src/gtk/theme-4.0/gtk-Light.css
+++ b/src/gtk/theme-4.0/gtk-Light.css
@@ -5695,8 +5695,6 @@ window {
   outline: none;
   box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.15), 0 8px 8px 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.12);
   margin: 0;
-  border-radius: 0;
-  transition: 200ms ease-out;
 }
 
 window:backdrop {

--- a/src/gtk/theme-4.0/gtk.css
+++ b/src/gtk/theme-4.0/gtk.css
@@ -5741,8 +5741,6 @@ window {
   outline: none;
   box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.15), 0 8px 8px 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.12);
   margin: 0;
-  border-radius: 0;
-  transition: 200ms ease-out;
 }
 
 window:backdrop {


### PR DESCRIPTION
1. Round border inside a gtk4 window:
<img width="892" height="620" alt="qogir_bug1" src="https://github.com/user-attachments/assets/d8a506be-cffa-40cd-9d81-b16aaa785bd1" />

2. Flickering in dark round theme when switching windows, running gtk4-demo:

https://github.com/user-attachments/assets/709a9fd5-3fea-41d9-8010-c1bf7b2e8caa

3. Headerbar border glitch in plain(no-suffix) round theme, running gtk4-demo:
**Edit**: cause problem, reverted.
<img width="1668" height="406" alt="qogir_bug2" src="https://github.com/user-attachments/assets/ab9aa162-fa3e-466a-87b3-103267661ba4" />


All those are small changes, so I just put them into one PR with separate commits.